### PR TITLE
base: Add minimal support for Richtap vibrations

### DIFF
--- a/core/java/android/os/RichTapVibrationEffect.java
+++ b/core/java/android/os/RichTapVibrationEffect.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.os;
+
+import android.content.res.Resources;
+import android.os.VibrationEffect;
+import android.util.Slog;
+
+import com.android.internal.R;
+
+/** @hide */
+public class RichTapVibrationEffect {
+
+    private static final String TAG = "RichTapVibrationEffect";
+
+    public static boolean isSupported() {
+        return Resources.getSystem().getBoolean(R.bool.config_usesRichtapVibration);
+    }
+
+    public static int[] getInnerEffect(int id) {
+        switch (id) {
+            case VibrationEffect.EFFECT_CLICK:
+                return new int[]{1, 4097, 0, 100, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            case VibrationEffect.EFFECT_DOUBLE_CLICK:
+                return new int[]{1, 4097, 0, 100, 80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4097, 70, 100, 80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            case VibrationEffect.EFFECT_TICK:
+                return new int[]{1, 4097, 0, 100, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            case VibrationEffect.EFFECT_THUD:
+                return new int[]{1, 4097, 0, 100, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            case VibrationEffect.EFFECT_POP:
+                return new int[]{1, 4097, 0, 100, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            case VibrationEffect.EFFECT_HEAVY_CLICK:
+                return new int[]{1, 4097, 0, 100, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            case VibrationEffect.EFFECT_TEXTURE_TICK:
+                return new int[]{1, 4097, 0, 50, 33, 29, 0, 0, 0, 12, 59, 0, 22, 75, -21, 29, 0, 0, 4097, 30, 100, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            default:
+                Slog.d(TAG, "Exception encountered!", new IllegalStateException("Unexpected effect id: " + id));
+                return null;
+        }
+    }
+
+    public static int getInnerEffectStrength(int strength) {
+        switch (strength) {
+            case VibrationEffect.EFFECT_STRENGTH_LIGHT:
+                return 150;
+            case VibrationEffect.EFFECT_STRENGTH_MEDIUM:
+                return 200;
+            case VibrationEffect.EFFECT_STRENGTH_STRONG:
+                return 250;
+            default:
+                Slog.e(TAG, "Wrong Effect Strength!!");
+                return 0;
+        }
+    }
+}

--- a/core/res/res/values/custom_config.xml
+++ b/core/res/res/values/custom_config.xml
@@ -68,4 +68,7 @@
 
     <!-- Expected value from fast charging status file  -->
     <string name="config_oemFastChargerStatusValue" translatable="false">1</string>
+
+    <!-- Whether to use Richtap vibration -->
+    <bool name="config_usesRichtapVibration">false</bool>
 </resources>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -113,4 +113,7 @@
     
     <!-- Cycle through ringer modes -->
     <java-symbol type="string" name="volume_dialog_ringer_guidance_normal" />
+
+    <!-- Whether to use Richtap vibration -->
+    <java-symbol type="bool" name="config_usesRichtapVibration" />
 </resources>

--- a/services/core/Android.bp
+++ b/services/core/Android.bp
@@ -242,6 +242,7 @@ java_library_static {
         "powerstats_flags_lib",
         "locksettings_flags_lib",
         "vendor.aospa.biometrics.face",
+        "vendor.aac.hardware.richtap.vibrator",
     ],
     javac_shard_size: 50,
     javacflags: [

--- a/services/core/java/com/android/server/vibrator/RichTapVibratorService.java
+++ b/services/core/java/com/android/server/vibrator/RichTapVibratorService.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.server.vibrator;
+
+import android.hardware.vibrator.IVibrator;
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.ServiceManager;
+import android.util.Slog;
+
+import vendor.aac.hardware.richtap.vibrator.IRichtapCallback;
+import vendor.aac.hardware.richtap.vibrator.IRichtapVibrator;
+
+public class RichTapVibratorService {
+
+    private static final String TAG = "RichTapVibratorService";
+    private static final String VIBRATOR_DESCRIPTOR = "android.hardware.vibrator.IVibrator/default";
+
+    private IRichtapCallback mCallback;
+    private volatile IRichtapVibrator sRichtapVibratorService = null;
+
+    private IRichtapVibrator getRichtapService() {
+        synchronized (RichTapVibratorService.class) {
+            if (sRichtapVibratorService == null) {
+                Slog.d(TAG, "vibratorDescriptor:" + VIBRATOR_DESCRIPTOR);
+                IVibrator vibratorHalService = IVibrator.Stub.asInterface(ServiceManager.getService(VIBRATOR_DESCRIPTOR));
+                if (vibratorHalService == null) {
+                    Slog.d(TAG, "can not get hal service");
+                    return null;
+                }
+                Slog.d(TAG, "vibratorHalService:" + vibratorHalService);
+                try {
+                    Slog.d(TAG, "Capabilities:" + vibratorHalService.getCapabilities());
+                } catch (Exception e) {
+                    Slog.d(TAG, "getCapabilities failed", e);
+                }
+                try {
+                    IBinder binder = vibratorHalService.asBinder().getExtension();
+                    if (binder != null) {
+                        sRichtapVibratorService = IRichtapVibrator.Stub.asInterface(Binder.allowBlocking(binder));
+                        binder.linkToDeath(new VibHalDeathRecipient(this), 0);
+                    } else {
+                        sRichtapVibratorService = null;
+                        Slog.e(TAG, "getExtension == null");
+                    }
+                } catch (Exception e) {
+                    Slog.e(TAG, "getExtension fail", e);
+                }
+            }
+            return sRichtapVibratorService;
+        }
+    }
+
+    public RichTapVibratorService() { }
+
+    public RichTapVibratorService(IRichtapCallback callback) {
+        mCallback = callback;
+    }
+
+    public void richTapVibratorOn(long millis) {
+        try {
+            IRichtapVibrator service = getRichtapService();
+            if (service != null) {
+                Slog.d(TAG, "aac richtap doVibratorOn");
+                service.on((int) millis, mCallback);
+            }
+        } catch (Exception e) {
+            Slog.e(TAG, "aac richtap doVibratorOn fail.", e);
+        }
+    }
+
+    public void richTapVibratorSetAmplitude(int amplitude) {
+        try {
+            IRichtapVibrator service = getRichtapService();
+            if (service != null) {
+                Slog.d(TAG, "aac richtap doVibratorSetAmplitude");
+                service.setAmplitude(amplitude, mCallback);
+            }
+        } catch (Exception e) {
+            Slog.e(TAG, "aac richtap doVibratorSetAmplitude fail.", e);
+        }
+    }
+
+    public void richTapVibratorOnRawPattern(int[] pattern, int amplitude, int freq) {
+        try {
+            IRichtapVibrator service = getRichtapService();
+            if (service != null) {
+                Slog.d(TAG, "aac richtap doVibratorOnRawPattern");
+                service.performHe(1, 0, amplitude, freq, pattern, mCallback);
+            }
+        } catch (Exception e) {
+            Slog.e(TAG, "aac richtap doVibratorOnRawPattern fail.", e);
+        }
+    }
+
+    void resetHalServiceProxy() {
+        sRichtapVibratorService = null;
+    }
+
+    public static final class VibHalDeathRecipient implements IBinder.DeathRecipient {
+        RichTapVibratorService mRichTapService;
+
+        VibHalDeathRecipient(RichTapVibratorService richtapService) {
+            mRichTapService = richtapService;
+        }
+
+        @Override
+        public void binderDied() {
+            Slog.d(TAG, "vibrator hal died,should reset hal proxy!!");
+            synchronized (VibHalDeathRecipient.class) {
+                if (mRichTapService != null) {
+                    Slog.d(TAG, "vibrator hal reset hal proxy");
+                    mRichTapService.resetHalServiceProxy();
+                }
+            }
+        }
+    }
+}

--- a/services/core/java/com/android/server/vibrator/VibratorController.java
+++ b/services/core/java/com/android/server/vibrator/VibratorController.java
@@ -23,6 +23,7 @@ import android.os.IVibratorStateListener;
 import android.os.Parcel;
 import android.os.RemoteCallbackList;
 import android.os.RemoteException;
+import android.os.RichTapVibrationEffect;
 import android.os.Trace;
 import android.os.VibrationEffect;
 import android.os.VibratorInfo;
@@ -59,6 +60,8 @@ final class VibratorController {
     private volatile boolean mIsUnderExternalControl;
     private volatile float mCurrentAmplitude;
 
+    private RichTapVibratorService mRichTapService;
+    
     /**
      * Listener for vibration completion callbacks from native.
      *
@@ -85,6 +88,10 @@ final class VibratorController {
         VibratorInfo.Builder vibratorInfoBuilder = new VibratorInfo.Builder(vibratorId);
         mVibratorInfoLoadSuccessful = mNativeWrapper.getInfo(vibratorInfoBuilder);
         mVibratorInfo = vibratorInfoBuilder.build();
+
+        if (RichTapVibrationEffect.isSupported()) {
+            mRichTapService = new RichTapVibratorService();
+        }
 
         if (!mVibratorInfoLoadSuccessful) {
             Slog.e(TAG,
@@ -257,7 +264,10 @@ final class VibratorController {
         Trace.traceBegin(Trace.TRACE_TAG_VIBRATOR, "VibratorController#setAmplitude");
         try {
             synchronized (mLock) {
-                if (mVibratorInfo.hasCapability(IVibrator.CAP_AMPLITUDE_CONTROL)) {
+                if (mRichTapService != null) {
+                    int strength = (int) (255.0f * amplitude);
+                    mRichTapService.richTapVibratorSetAmplitude(strength);
+                } else if (mVibratorInfo.hasCapability(IVibrator.CAP_AMPLITUDE_CONTROL)) {
                     mNativeWrapper.setAmplitude(amplitude);
                 }
                 if (mIsVibrating) {
@@ -282,7 +292,13 @@ final class VibratorController {
         Trace.traceBegin(Trace.TRACE_TAG_VIBRATOR, "VibratorController#on");
         try {
             synchronized (mLock) {
-                long duration = mNativeWrapper.on(milliseconds, vibrationId);
+                long duration = 0;
+                if (mRichTapService != null) {
+                    duration = milliseconds;
+                    mRichTapService.richTapVibratorOn(duration);
+                } else {
+                    duration = mNativeWrapper.on(milliseconds, vibrationId);
+                }
                 if (duration > 0) {
                     mCurrentAmplitude = -1;
                     notifyListenerOnVibrating(true);
@@ -338,8 +354,18 @@ final class VibratorController {
         Trace.traceBegin(Trace.TRACE_TAG_VIBRATOR, "VibratorController#on (Prebaked)");
         try {
             synchronized (mLock) {
-                long duration = mNativeWrapper.perform(prebaked.getEffectId(),
-                        prebaked.getEffectStrength(), vibrationId);
+                long duration = 0;
+                if (mRichTapService != null) {
+                    int[] pattern = RichTapVibrationEffect.getInnerEffect(prebaked.getEffectId());
+                    int strength = RichTapVibrationEffect.getInnerEffectStrength(prebaked.getEffectStrength());
+                    if (pattern != null) {
+                        duration = 30;
+                        mRichTapService.richTapVibratorOnRawPattern(pattern, strength, 0);
+                    }
+                } else {
+                    duration = mNativeWrapper.perform(prebaked.getEffectId(),
+                            prebaked.getEffectStrength(), vibrationId);
+                }
                 if (duration > 0) {
                     mCurrentAmplitude = -1;
                     notifyListenerOnVibrating(true);


### PR DESCRIPTION
This implementation of Richtap is highly inspired by Nothings but stripped down to its essentials to match our needs.

If your device supports Richtap vibrations set "config_usesRichtapVibration" to true and enjoy!
