### PR TITLE
Make AOSP native freeform windows always-on-top

### DIFF
--- a/core/java/android/app/WindowConfiguration.java
+++ b/core/java/android/app/WindowConfiguration.java
@@ -397,6 +397,10 @@ public class WindowConfiguration implements Parcelable, Comparable<WindowConfigu
 
     public void setWindowingMode(@WindowingMode int windowingMode) {
         mWindowingMode = windowingMode;
+        // Automatically set always-on-top for freeform windows
+        if (windowingMode == WINDOWING_MODE_FREEFORM) {
+            setAlwaysOnTop(true);
+        }
     }
 
     @WindowingMode


### PR DESCRIPTION
This commit makes aosp native freeform always-on-top. 
Although we already set always-on-top [here](https://github.com/RisingOS-staging/android_packages_apps_LMOFreeform/blob/c01135e48eb0e362f874c1286876f2865b00eab0/app/src/main/java/com/libremobileos/freeform/receiver/StartFreeformReceiver.kt#L99), it does not affect other windows that are created from window exactly opened from sidebar. For example, without signing a google account, open play store via sidebar, the main window will disappear and it creates a new window for sign-in. In cases like that, settings in lmofreeform does not work. So this commit set always-on-top in WindowConfiguration.java to make sure it affects all freeform windows.

Demo:
Without this commit: 

https://github.com/user-attachments/assets/106f3f0c-bb7f-40cf-ab3f-b1c934f16d5f

With this commit:

https://github.com/user-attachments/assets/76d154d0-6120-471a-a5ad-115f958d176c



Close https://github.com/RisingTechOSS/issue_tracker/issues/77